### PR TITLE
59 Tmp columns removed from configs

### DIFF
--- a/datasetComparison/src/main/resources/reference.conf
+++ b/datasetComparison/src/main/resources/reference.conf
@@ -1,7 +1,5 @@
 dataset-comparison {
   errColumn = "errCol"
-  tmpColumn = "tmp"
-  comparisonUniqueId = "ComparisonUniqueId"
   actualPrefix = "actual"
   expectedPrefix = "expected"
   allowDuplicates = false

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/cliUtils/CliOptions.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/cliUtils/CliOptions.scala
@@ -24,7 +24,7 @@ import scala.util.{Failure, Success, Try}
 case class CliOptions(referenceOptions: DataframeOptions,
                       newOptions: DataframeOptions,
                       outPath: String,
-                      keys: Option[Set[String]],
+                      keys: Set[String],
                       rawOptions: String)
 
 object CliOptions {
@@ -46,7 +46,10 @@ object CliOptions {
     val mapOfGroups: Map[String, String] = args.grouped(2).map{ a => (a(0).drop(2) -> a(1)) }.toMap
     val refMap = mapOfGroups.filterKeys(_ matches "ref-.*")
     val newMap = mapOfGroups.filterKeys(_ matches "new-.*")
-    val keys = mapOfGroups.get("keys").map { x => x.split(",").toSet }
+    val keys = mapOfGroups.get("keys") match {
+      case Some(x) => x.split(",").toSet
+      case None    => Set.empty[String]
+    }
     val outPath = mapOfGroups.getOrElse("out-path", throw new MissingArgumentException("""out-path is mandatory option. Use "--out-path"."""))
     val genericMap = mapOfGroups -- refMap.keys -- newMap.keys -- Set("keys", "out-path")
 

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/config/DatasetComparisonConfig.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/config/DatasetComparisonConfig.scala
@@ -17,8 +17,6 @@ package za.co.absa.hermes.datasetComparison.config
 
 abstract class DatasetComparisonConfig {
   val errorColumnName: String
-  val tmpColumnName: String
-  val comparisonUniqueId: String
   val actualPrefix: String
   val expectedPrefix: String
   val allowDuplicates: Boolean

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/config/ManualConfig.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/config/ManualConfig.scala
@@ -2,8 +2,6 @@ package za.co.absa.hermes.datasetComparison.config
 
 class ManualConfig(
   val errorColumnName: String,
-  val tmpColumnName: String,
-  val comparisonUniqueId: String,
   val actualPrefix: String,
   val expectedPrefix: String,
   val allowDuplicates: Boolean

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/config/TypesafeConfig.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/config/TypesafeConfig.scala
@@ -24,8 +24,6 @@ class TypesafeConfig(path: Option[String]) extends DatasetComparisonConfig {
   }
 
   val errorColumnName: String = conf.getString("dataset-comparison.errColumn")
-  val tmpColumnName: String = conf.getString("dataset-comparison.tmpColumn")
-  val comparisonUniqueId: String = conf.getString("dataset-comparison.comparisonUniqueId")
   val actualPrefix: String = conf.getString("dataset-comparison.actualPrefix")
   val expectedPrefix: String = conf.getString("dataset-comparison.expectedPrefix")
   val allowDuplicates: Boolean = conf.getBoolean("dataset-comparison.allowDuplicates")

--- a/datasetComparison/src/test/resources/application.conf
+++ b/datasetComparison/src/test/resources/application.conf
@@ -1,7 +1,5 @@
 dataset-comparison {
   errColumn = "errCol"
-  tmpColumn = "tmp"
-  comparisonUniqueId = "ComparisonUniqueId"
   actualPrefix = "actual"
   expectedPrefix = "expected"
   allowDuplicates = false

--- a/datasetComparison/src/test/resources/confData/application.conf
+++ b/datasetComparison/src/test/resources/confData/application.conf
@@ -1,7 +1,5 @@
 dataset-comparison {
   errColumn = "errCol2"
-  tmpColumn = "tmp2"
-  comparisonUniqueId = "ComparisonUniqueId2"
   actualPrefix = "actual2"
   expectedPrefix = "expected2"
   allowDuplicates = true

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonSuite.scala
@@ -16,24 +16,22 @@
 package za.co.absa.hermes.datasetComparison
 
 import org.apache.spark.sql.Column
-import org.scalatest.FunSuite
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import za.co.absa.hermes.datasetComparison.cliUtils.{CliOptions, DataframeOptions}
 import za.co.absa.hermes.datasetComparison.config.ManualConfig
 import za.co.absa.hermes.utils.SparkTestBase
 
-class DatasetComparisonSuite extends FunSuite with SparkTestBase {
+class DatasetComparisonSuite extends FunSuite with SparkTestBase with BeforeAndAfterAll {
   test("Test a positive comparison") {
     val cliOptions = new CliOptions(
       DataframeOptions("csv", Map("delimiter" -> ","), getClass.getResource("/dataSample2.csv").toString),
       DataframeOptions("csv", Map("delimiter" -> ","), getClass.getResource("/dataSample1.csv").toString),
       "path/to/nowhere",
-      None,
+      Set.empty[String],
       "--bogus raw-options"
     )
     val manualConfig = new ManualConfig(
       "errCol",
-      "tmp",
-      "comparisonUniqueId",
       "actual",
       "expected",
       true
@@ -62,13 +60,11 @@ class DatasetComparisonSuite extends FunSuite with SparkTestBase {
       DataframeOptions("csv", Map("delimiter" -> ",", "header" -> "true"), getClass.getResource("/dataSample1.csv").toString),
       DataframeOptions("csv", Map("delimiter" -> ",", "header" -> "true"), getClass.getResource("/dataSample6.csv").toString),
       "path/to/nowhere",
-      Some(Set("id", "first_name")),
+      Set("id", "first_name"),
       "--bogus raw-options"
     )
     val manualConfig = new ManualConfig(
       "errCol",
-      "tmp",
-      "comparisonUniqueId",
       "actual",
       "expected",
       true

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/cliUtils/CliOptionsSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/cliUtils/CliOptionsSuite.scala
@@ -67,7 +67,7 @@ class CliOptionsSuite extends FunSuite {
       refDataframeOptions,
       newDataframeOptions,
       "/some/out/path",
-      Some(Set("alfa", "beta")),
+      Set("alfa", "beta"),
       args.mkString(" "))
 
     assert(cliOptions == CliOptions.parse(args))

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/config/TypeSafeConfigSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/config/TypeSafeConfigSuite.scala
@@ -21,8 +21,6 @@ class TypeSafeConfigSuite extends FunSuite {
   test("Default Config Loaded") {
     val conf = new TypesafeConfig(None)
     assert("errCol" == conf.errorColumnName)
-    assert("tmp" == conf.tmpColumnName)
-    assert("ComparisonUniqueId" == conf.comparisonUniqueId)
     assert("actual" == conf.actualPrefix)
     assert("expected" == conf.expectedPrefix)
     assert(!conf.allowDuplicates)
@@ -32,8 +30,6 @@ class TypeSafeConfigSuite extends FunSuite {
     val conf = new TypesafeConfig(Some("confData/application.conf"))
 
     assert("errCol2" == conf.errorColumnName)
-    assert("tmp2" == conf.tmpColumnName)
-    assert("ComparisonUniqueId2" == conf.comparisonUniqueId)
     assert("actual2" == conf.actualPrefix)
     assert("expected2" == conf.expectedPrefix)
     assert(conf.allowDuplicates)

--- a/e2eRunner/src/main/scala/za/co/absa/hermes/e2eRunner/E2ERunnerJob.scala
+++ b/e2eRunner/src/main/scala/za/co/absa/hermes/e2eRunner/E2ERunnerJob.scala
@@ -67,7 +67,7 @@ object E2ERunnerJob {
   }
 
   private def getDatasetComparisonConfig(cmd: E2ERunnerConfig, pathHDFS: String): CliOptions = {
-    val keys = if (cmd.keys.isDefined) { Some(cmd.keys.get.toSet) } else { None }
+    val keys = if (cmd.keys.isDefined) { cmd.keys.get.toSet } else { Set.empty[String] }
 
     CliOptions(
       DataframeOptions("parquet", Map.empty[String, String], s"/ref$pathHDFS"),


### PR DESCRIPTION
### Description
This PR fixes 2 issues
- Removing `tmpColum` and `comparisonUniqueId` from configs (Closes #59)
- Unpredictable behaviours because of possible concatenation issues (Closes #60)

### Previous behaviour
- previously you could specify `tmpColum` and `comparisonUniqueId` in application conf or while running the spark job. This was decided as not needed and error-prone.
- CliOptions's Keys changed from `Option[Set[String]]` to `Set[String]` so the call had to be modified
- If we had 2 key columns pairs with ["01", "1"] and ["0", "11"], this would behave unpredictably because this would be concatenated to the same string would produce the same md5 sum.

### Current behaviour
- `tmpColum` and `comparisonUniqueId` are generated automatically
- CliOptions's Keys not an Option anymore. Empty Set represents nothing
- key columns are now concatenated with a delimiter "|"

### Modules affected
- [x] DatasetComparison
  - Most logic is here
- [ ] InfoFileComparison
- [x] E2ERunner
  - CliOption Keys change 

### Other
- [x] Has new configs 
- [x] Requires Docs update (done in #69)
- [ ] Introduces new logs
- [ ] Introduces new error messages