### PR TITLE
73 Add schema option for Dataset comparison

### DIFF
--- a/datasetComparison/src/main/resources/cli_options.json
+++ b/datasetComparison/src/main/resources/cli_options.json
@@ -29,6 +29,11 @@
       "text":  "Unique columns that will be used as an anchor for data comparison. Without them, the comparison cannot give paths to differences"
     },
     {
+      "key": "--schema",
+      "optional": "optional",
+      "text":  "A schema path on HDFS. This will allow to cherry pick columns from the two data sets to compare"
+    },
+    {
       "key": "others",
       "optional": "optional",
       "text":  "Options like delimiter, header, rowTag, user, password, url, ... These are the specific options for specific formats used. For more information, check sparks documentation on what all the options for the format you are using"

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparison.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparison.scala
@@ -15,7 +15,7 @@
 
 package za.co.absa.hermes.datasetComparison
 
-import org.apache.spark.sql.functions.{array, col, concat, concat_ws, lit, md5, when}
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 import za.co.absa.hermes.datasetComparison.cliUtils.CliOptions
@@ -32,7 +32,8 @@ import za.co.absa.hermes.utils.HelperFunctions
  * @param sparkSession Implicit spark session.
  */
 class DatasetComparison(cliOptions: CliOptions,
-                        config: DatasetComparisonConfig)
+                        config: DatasetComparisonConfig,
+                        optionalSchema: Option[StructType] = None)
                        (implicit sparkSession: SparkSession) {
 
   /**
@@ -56,9 +57,12 @@ class DatasetComparison(cliOptions: CliOptions,
     val testedDF = ComparisonPair(cliOptions.referenceOptions.loadDataFrame, cliOptions.newOptions.loadDataFrame)
     val rowCounts = ComparisonPair(testedDF.reference.count(), testedDF.actual.count())
 
-    checkSchemas(testedDF)
+    optionalSchema match {
+      case Some(schema) => checkSchemas(testedDF, schema)
+      case None => checkSchemas(testedDF)
+    }
 
-    val selector: List[Column] = SchemaUtils.getDataFrameSelector(testedDF.reference.schema)
+    val selector: List[Column] = SchemaUtils.getDataFrameSelector(optionalSchema.getOrElse(testedDF.reference.schema))
     val dfsSorted = ComparisonPair(
       SchemaUtils.alignSchema(testedDF.reference, selector),
       SchemaUtils.alignSchema(testedDF.actual, selector)
@@ -132,16 +136,33 @@ class DatasetComparison(cliOptions: CliOptions,
   /**
    * Performs a check if the schemas of two data frames are actually the same.
    *
-   * @param testedDf Comparison pair of two DataFrames whose schema will be tested
+   * @param testedDF Comparison pair of two DataFrames whose schema will be tested
    */
-  private def checkSchemas(testedDf: ComparisonPair[DataFrame]): Unit = {
-    val expectedSchema: StructType = getSchemaWithoutMetadata(testedDf.reference.schema)
-    val actualSchema: StructType = getSchemaWithoutMetadata(testedDf.actual.schema)
+  private def checkSchemas(testedDF: ComparisonPair[DataFrame]): Unit = {
+    val expectedSchema: StructType = getSchemaWithoutMetadata(testedDF.reference.schema)
+    val actualSchema: StructType = getSchemaWithoutMetadata(testedDF.actual.schema)
 
     if (!SchemaUtils.isSameSchema(expectedSchema, actualSchema)) {
       val diffSchema = SchemaUtils.diffSchema(expectedSchema, actualSchema) ++
         SchemaUtils.diffSchema(actualSchema, expectedSchema)
       throw SchemasDifferException(cliOptions.referenceOptions.path, cliOptions.newOptions.path, diffSchema.mkString("\n"))
+    }
+  }
+
+  /**
+   * Performs a check if the schemas of two data frames are supersets of schema provided..
+   *
+   * @param testedDF Comparison pair of two DataFrames whose schema will be tested
+   * @param schema Schema that needs to be a subset of schemas provided by data sets
+   */
+  def checkSchemas(testedDF: ComparisonPair[DataFrame], schema: StructType): Unit = {
+    val expectedSchema: StructType = getSchemaWithoutMetadata(testedDF.reference.schema)
+    val actualSchema: StructType = getSchemaWithoutMetadata(testedDF.actual.schema)
+
+    if (!(SchemaUtils.doesSchemaComply(schema, actualSchema) && SchemaUtils.doesSchemaComply(schema, expectedSchema))) {
+      val diffSchema = SchemaUtils.diffSchema(schema, actualSchema) ++
+        SchemaUtils.diffSchema(schema, expectedSchema)
+      throw BadProvidedSchema(cliOptions.referenceOptions.path, cliOptions.newOptions.path, diffSchema.mkString("\n"))
     }
   }
 

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonJob.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonJob.scala
@@ -19,6 +19,7 @@ import java.io.PrintWriter
 
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.{DataType, StructType}
 import za.co.absa.hermes.datasetComparison.cliUtils.CliOptions
 import za.co.absa.hermes.datasetComparison.config.TypesafeConfig
 
@@ -47,7 +48,13 @@ object DatasetComparisonJob {
   def execute(cliOptions: CliOptions, configPath: Option[String] = None)
              (implicit sparkSession: SparkSession): Unit = {
     val config = new TypesafeConfig(configPath)
-    val dsComparison = new DatasetComparison(cliOptions, config)
+    val optionalSchema = cliOptions.schemaPath match {
+      case Some(schema) =>
+        val schemaSource = sparkSession.sparkContext.wholeTextFiles(schema).take(1)(0)._2
+        Some(DataType.fromJson(schemaSource).asInstanceOf[StructType])
+      case None => None
+    }
+    val dsComparison = new DatasetComparison(cliOptions, config, optionalSchema)
     val result = dsComparison.compare
 
     result.resultDF.foreach { df => df.write.format("parquet").save(cliOptions.outPath) }

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/Exceptions.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/Exceptions.scala
@@ -44,6 +44,17 @@ final case class SchemasDifferException(refPath: String,
        |$diffSchema""".stripMargin,
     cause)
 
+final case class BadProvidedSchema(refPath: String,
+                                   stdPath: String,
+                                   diffSchema: String,
+                                   cause: Throwable = None.orNull)
+  extends DatasetComparisonException(
+    s"""Provided schema is not a subset of Expected and Actual dataset's schemas.
+       |Reference path: $refPath
+       |Actual dataset path: $stdPath
+       |Difference is:
+       |$diffSchema""".stripMargin,
+    cause)
 
 final case class DuplicateRowsInDF(path: String)
   extends DatasetComparisonException(s"Provided dataset has duplicate rows. Specific rows written to $path")

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/cliUtils/CliOptions.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/cliUtils/CliOptions.scala
@@ -25,7 +25,8 @@ case class CliOptions(referenceOptions: DataframeOptions,
                       newOptions: DataframeOptions,
                       outPath: String,
                       keys: Set[String],
-                      rawOptions: String)
+                      rawOptions: String,
+                      schemaPath: Option[String] = None)
 
 object CliOptions {
   def generateHelp: Unit = {
@@ -46,12 +47,14 @@ object CliOptions {
     val mapOfGroups: Map[String, String] = args.grouped(2).map{ a => (a(0).drop(2) -> a(1)) }.toMap
     val refMap = mapOfGroups.filterKeys(_ matches "ref-.*")
     val newMap = mapOfGroups.filterKeys(_ matches "new-.*")
+    val schema = mapOfGroups.get("schema")
     val keys = mapOfGroups.get("keys") match {
       case Some(x) => x.split(",").toSet
       case None    => Set.empty[String]
     }
+
     val outPath = mapOfGroups.getOrElse("out-path", throw new MissingArgumentException("""out-path is mandatory option. Use "--out-path"."""))
-    val genericMap = mapOfGroups -- refMap.keys -- newMap.keys -- Set("keys", "out-path")
+    val genericMap = mapOfGroups -- refMap.keys -- newMap.keys -- Set("keys", "out-path", "schema")
 
     val refMapWithoutPrefix = refMap.map { case (key, value) => (key.drop(4), value) }
     val newMapWithoutPrefix = newMap.map { case (key, value) => (key.drop(4), value) }
@@ -73,7 +76,7 @@ object CliOptions {
         throw MissingArgumentException(message, exception)
     }
 
-    CliOptions(refLoadOptions, newLoadOptions, outPath, keys, args.mkString(" "))
+    CliOptions(refLoadOptions, newLoadOptions, outPath, keys, args.mkString(" "), schema)
   }
 
   /**

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/cliUtils/CliOptions.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/cliUtils/CliOptions.scala
@@ -54,7 +54,6 @@ object CliOptions {
       case None    => Set.empty[String]
     }
 
-    val outPath = mapOfGroups.getOrElse("out-path", throw new MissingArgumentException("""out-path is mandatory option. Use "--out-path"."""))
     val genericMap = mapOfGroups -- refMap.keys -- newMap.keys -- outMap.keys -- Set("keys", "schema")
 
     val refMapWithoutPrefix = refMap.map { case (key, value) => (key.drop(4), value) }
@@ -87,7 +86,7 @@ object CliOptions {
         throw MissingArgumentException(message, exception)
     }
 
-    CliOptions(refLoadOptions, newLoadOptions, outLoadOptions, keys, args.mkString(" "))
+    CliOptions(refLoadOptions, newLoadOptions, outLoadOptions, keys, args.mkString(" "), schema)
   }
 
   /**

--- a/datasetComparison/src/test/resources/dataSample1Schema.json
+++ b/datasetComparison/src/test/resources/dataSample1Schema.json
@@ -1,0 +1,29 @@
+{
+  "type" : "struct",
+  "fields" : [ {
+    "name" : "_c0",
+    "type" : "string",
+    "nullable" : true,
+    "metadata" : { }
+  }, {
+    "name" : "_c1",
+    "type" : "string",
+    "nullable" : true,
+    "metadata" : { }
+  }, {
+    "name" : "_c2",
+    "type" : "string",
+    "nullable" : true,
+    "metadata" : { }
+  }, {
+    "name" : "_c3",
+    "type" : "string",
+    "nullable" : true,
+    "metadata" : { }
+  }, {
+    "name" : "_c4",
+    "type" : "string",
+    "nullable" : true,
+    "metadata" : { }
+  } ]
+}

--- a/datasetComparison/src/test/resources/dataSample1WrongSchema.json
+++ b/datasetComparison/src/test/resources/dataSample1WrongSchema.json
@@ -1,0 +1,29 @@
+{
+  "type" : "struct",
+  "fields" : [ {
+    "name" : "_c01",
+    "type" : "string",
+    "nullable" : true,
+    "metadata" : { }
+  }, {
+    "name" : "_c1",
+    "type" : "string",
+    "nullable" : true,
+    "metadata" : { }
+  }, {
+    "name" : "_c2",
+    "type" : "string",
+    "nullable" : true,
+    "metadata" : { }
+  }, {
+    "name" : "_c3",
+    "type" : "string",
+    "nullable" : true,
+    "metadata" : { }
+  }, {
+    "name" : "_c4",
+    "type" : "string",
+    "nullable" : true,
+    "metadata" : { }
+  } ]
+}

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonSuite.scala
@@ -60,7 +60,7 @@ class DatasetComparisonSuite extends FunSuite with SparkTestBase with BeforeAndA
     val cliOptions = new CliOptions(
       DataframeOptions("csv", Map("delimiter" -> ","), getClass.getResource("/dataSample2.csv").toString),
       DataframeOptions("csv", Map("delimiter" -> ","), getClass.getResource("/dataSample1.csv").toString),
-      "path/to/nowhere",
+      DataframeOptions("parquet", Map.empty[String, String], "path/to/nowhere"),
       Set.empty[String],
       "--bogus raw-options",
       Some(getClass.getResource("/dataSample1Schema.json").toString)
@@ -99,7 +99,7 @@ class DatasetComparisonSuite extends FunSuite with SparkTestBase with BeforeAndA
     val cliOptions = new CliOptions(
       DataframeOptions("csv", Map("delimiter" -> ","), getClass.getResource("/dataSample2.csv").toString),
       DataframeOptions("csv", Map("delimiter" -> ","), getClass.getResource("/dataSample1.csv").toString),
-      "path/to/nowhere",
+      DataframeOptions("parquet", Map.empty[String, String], "path/to/nowhere"),
       Set.empty[String],
       "--bogus raw-options"
     )

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonSuite.scala
@@ -16,6 +16,7 @@
 package za.co.absa.hermes.datasetComparison
 
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.types.{StringType, StructType}
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import za.co.absa.hermes.datasetComparison.cliUtils.{CliOptions, DataframeOptions}
 import za.co.absa.hermes.datasetComparison.config.ManualConfig
@@ -53,6 +54,83 @@ class DatasetComparisonSuite extends FunSuite with SparkTestBase with BeforeAndA
     val cmpResult = new DatasetComparison(cliOptions, manualConfig).compare
 
     assert(expectedResult == cmpResult)
+  }
+
+  test("Test a positive comparison with provided schema") {
+    val cliOptions = new CliOptions(
+      DataframeOptions("csv", Map("delimiter" -> ","), getClass.getResource("/dataSample2.csv").toString),
+      DataframeOptions("csv", Map("delimiter" -> ","), getClass.getResource("/dataSample1.csv").toString),
+      "path/to/nowhere",
+      Set.empty[String],
+      "--bogus raw-options",
+      Some(getClass.getResource("/dataSample1Schema.json").toString)
+    )
+    val manualConfig = new ManualConfig(
+      "errCol",
+      "actual",
+      "expected",
+      true
+    )
+    val expectedResult = ComparisonResult(
+      10, 10, 0, 0, 10,
+      List(
+        new Column("_c0"),
+        new Column("_c1"),
+        new Column("_c2"),
+        new Column("_c3"),
+        new Column("_c4")
+      ),
+      None, 0,
+      "--bogus raw-options"
+    )
+    val schema = new StructType()
+      .add("_c0", StringType, true)
+      .add("_c1", StringType, true)
+      .add("_c2", StringType, true)
+      .add("_c3", StringType, true)
+      .add("_c4", StringType, true)
+
+    val cmpResult = new DatasetComparison(cliOptions, manualConfig, Some(schema)).compare
+
+    assert(expectedResult == cmpResult)
+  }
+
+  test("Test a negative comparison with wrong provided schema") {
+    val cliOptions = new CliOptions(
+      DataframeOptions("csv", Map("delimiter" -> ","), getClass.getResource("/dataSample2.csv").toString),
+      DataframeOptions("csv", Map("delimiter" -> ","), getClass.getResource("/dataSample1.csv").toString),
+      "path/to/nowhere",
+      Set.empty[String],
+      "--bogus raw-options"
+    )
+    val manualConfig = new ManualConfig(
+      "errCol",
+      "actual",
+      "expected",
+      true
+    )
+    val expectedResult = ComparisonResult(
+      10, 10, 0, 0, 10,
+      List(
+        new Column("_c0"),
+        new Column("_c1"),
+        new Column("_c2"),
+        new Column("_c3"),
+        new Column("_c4")
+      ),
+      None, 0,
+      "--bogus raw-options"
+    )
+    val schema = new StructType()
+      .add("_c01", StringType, true)
+      .add("_c1", StringType, true)
+      .add("_c2", StringType, true)
+      .add("_c3", StringType, true)
+      .add("_c4", StringType, true)
+
+    intercept[BadProvidedSchema] {
+      new DatasetComparison(cliOptions, manualConfig, Some(schema)).compare
+    }
   }
 
   test("Compare datasets with duplicates disallowed") {

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/cliUtils/CliOptionsSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/cliUtils/CliOptionsSuite.scala
@@ -32,6 +32,7 @@ class CliOptionsSuite extends FunSuite {
                            |--new-path|--new-dbtable  mandatory  Path to the newly created source or name of the table
                            |--ref-path|--ref-dbtable  mandatory  Path to the referential source or name of the table
                            |--keys                    optional   Unique columns that will be used as an anchor for data comparison. Without them, the comparison cannot give paths to differences
+                           |--schema                  optional   A schema path on HDFS. This will allow to cherry pick columns from the two data sets to compare
                            |others                    optional   Options like delimiter, header, rowTag, user, password, url, ... These are the specific options for specific formats used. For more information, check sparks documentation on what all the options for the format you are using
                            |""".stripMargin
     Console.withOut(outCapture) { CliOptions.generateHelp }


### PR DESCRIPTION
This commit will allow the user to specify path to a schema on HDFS that they want to use. This will then allow them to cherry-pick column for dataset comparison.

Closes #73 