### PR TITLE
77 Add Community Standard Files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+---
+name: BugFix PR
+about: Create a PR for a Bugfix
+title: 'ISSUE_NUMBER - Name'
+labels: ''
+assignees: ''
+
+---
+
+### Description
+
+### Previous behaviour
+
+### Current behaviour
+
+### Modules affected
+- [ ] DatasetComparison
+- [ ] InfoFileComparison
+- [ ] E2ERunner
+
+### Other
+- [ ] Has new configs 
+- [ ] Requires Docs update
+- [ ] Introduces new logs
+- [ ] Introduces new error messages
+
+Fixes #ISSUE_NUMBER

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at bisonCore@absa.co.za. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# How To Contribute To Hermes
+ 
+## **Did you find a bug?**
+
+* **Ensure the bug has not already been reported** by searching our **[GitHub Issues][issues]**.
+* If you are unable to find an open issue describing the problem, use the **Bug report** template to open a new one. Tag it with the **bug** label.
+
+## **Do you want to request a new feature?**
+
+* **Ensure the feature has not already been requested** by searching our **[GitHub Issues][issues]**.
+* If you are unable to find the feature request, create a new one. Tag it with the **request** label.
+
+## **Do you want to implement a new feature or fix a bug?**
+
+* Check logs for the feature/bug. Check if someone isn't already working on it.
+  * If the feature/bug is not yet filed, please write it up first:
+    * **"Life, the universe and everything"**
+* Fork the repository.
+* We follow the [**GitFlow**][git-flow] branching strategy:
+  * Cut your branch from develop, add the GitHub Issue in the branch name:
+    * **feature/42-life-universe-everything**
+    * **bugfix/42-life-universe-everything**
+* Code away. Ask away. Work with us.
+  * Commit messages should start with a reference to the GitHub Issue and provide a brief description in the imperative mood:
+    * **"#42 Answer the ultimate question"**
+  * Don't forget to write tests for your work.
+* After finishing everything, push to your forked repo and open a Pull Request to our develop branch:
+  * Pull Request titles should start with the Github Issue number:
+    * **"42 Life, the universe and everything"**
+  * Ensure the Pull Request description clearly describes the solution.
+
+##### Thanks!
+
+The AbsaOSS team
+
+[issues]: https://github.com/AbsaOSS/hermes/issues
+[git-flow]: https://nvie.com/posts/a-successful-git-branching-model/

--- a/README.md
+++ b/README.md
@@ -1,27 +1,35 @@
 # Enceladus TestUtils
-___
-<!-- toc -->
 
-- [Dataset Comparison](#dataset-comparison)
-- [Info Comparison](#info-comparison)
-- [E2E Runner](#e2e-runner)
+- [Enceladus TestUtils](#enceladus-testutils)
+  - [To Build](#to-build)
+  - [Dataset Comparison](#dataset-comparison)
+    - [Running](#running)
+      - [Where](#where)
+  - [Info File Comparison](#info-file-comparison)
+    - [Running](#running-1)
+  - [E2E Runner](#e2e-runner)
 
-<!-- tocstop -->
-## Build
+Hermes is an E2E testing tool created mainly for the use in [ABSA OSS][gh-absa] ecosystem but still provides some tools/utils that are usable in other projects and are quite generic. For more information, please look at our [Hermes Github Pages][gh-pages].
+
+## To Build
+
 ```bash
 sbt assembly
 ```
 
-Known to work with: 
+Known to work with:
+
 - Spark 2.4.4
 - Java 1.8.0_191-b12
 - Scala 2.11.12
-- Hadoop 2.7.5 
+- Hadoop 2.7.5
 
-## <a name="dataset-comparison" />Dataset Comparison
-A Spark job for comparing two data sets. 
+## Dataset Comparison
+
+Spark job for the comparison of data sets. As it leverages spark, there are almost no limitations to data sources and size of the data.
 
 ### Running
+
 Basic running example
 ```bash
 spark-submit \
@@ -61,11 +69,14 @@ Usage: spark-submit [spark options] --class za.co.absa.hermes.datasetComparison.
 
 Other configurations are Spark dependant and are out of scope of this README.
 
-##  <a name="info-comparison" />Info File Comparison
-Autm's Info file comparison. Ran as part of the E2E Runner. Can be run as a plain old jar file.
+## Info File Comparison
+
+[Autm][atum]'s (and it's derivatives) Info file comparison. Ran as part of the E2E Runner. Can be run as a plain old jar file.
 
 ### Running
+
 Basic running example
+
 ```bash
 java -jar \
 /path/to/jar/file \
@@ -74,11 +85,14 @@ java -jar \
 --out-path /path/to/diff/output
 ```
 
-##  <a name="e2e-runner" />E2E Runner
-Runs both Standardization and Conformance on the data provided. After each, a comparison job is run 
-to check the results against expected reference data.
+## E2E Runner
+
+Currently runs both Standardization and Conformance of [Enceladus][enceladus] project on the data provided. After each, a comparison job is run to check the results against expected reference data.
+
+This tool is planed for an upgrade in the nearest future to be a general E2E Runner for user defined runes.
 
 Basic running example:
+
 ```bash
 spark-submit \
 /path/to/jar/file \
@@ -90,3 +104,7 @@ spark-submit \
 --raw-format <rawFormat>
 --keys <key1,key2,...>
 ```
+
+[gh-absa]: https://github.com/AbsaOSS
+[gh-pages]: https://absaoss.github.io/hermes/
+[atum]: https://github.com/AbsaOSS/atum


### PR DESCRIPTION
### Description
- add Code of Conduct
- add Contributing guide line
- add a single PR template. Multiple are not picked up by the UI and
need to be added to URL automatically. Leaving those for now, if we
change workflow in the future.
- Update README.md

### Current behaviour
- now PR template, the default one, should be automatically picked by the UI

Fixes #77 