### PR TITLE
83 Remove duplicte writing feature

### DIFF
--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparison.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparison.scala
@@ -75,7 +75,7 @@ class DatasetComparison(cliOptions: CliOptions,
       addKeyColumn(selector, dfsSorted.actual, cmpUniqueColumn)
     )
 
-    val duplicateCounts = handleDuplicates(dfsWithKey, cmpUniqueColumn)
+    val duplicateCounts: ComparisonPair[Long] = handleDuplicates(dfsWithKey, cmpUniqueColumn)
 
     val dfsExcepted = ComparisonPair(
       dfsWithKey.reference.except(dfsWithKey.actual),
@@ -166,22 +166,13 @@ class DatasetComparison(cliOptions: CliOptions,
   }
 
   /**
-   * Handles duplicates in a sense that this method looks for them. Then based on the configuration if found, throws an
-   * error, does deduplication or just passes through.
+   * Handles duplicates in a sense that this method looks for them based on a primary key. Then based on the
+   * configuration, if found, throws an error.
    *
    * @param dfsWithKey DataFrame pair where both have appended unique key
-   * @return
+   * @return A Pair for comparison counts
    */
   private def handleDuplicates(dfsWithKey: ComparisonPair[DataFrame], cmpUniqueColumn: String): ComparisonPair[Long] = {
-    def write(df: DataFrame, duplicates: DataFrame, extraPath: String): Unit = {
-      val cleanedDF = df.alias("original")
-        .join(duplicates, Seq(cmpUniqueColumn), "inner")
-        .select("original.*")
-        .drop(cmpUniqueColumn)
-
-      cliOptions.outOptions.writeDataFrame(cleanedDF, extraPath)
-    }
-
     val dfsDuplicates: ComparisonPair[Option[DataFrame]] = ComparisonPair(
       checkForDuplicateRows(dfsWithKey.reference, cmpUniqueColumn),
       checkForDuplicateRows(dfsWithKey.actual, cmpUniqueColumn)
@@ -193,10 +184,7 @@ class DatasetComparison(cliOptions: CliOptions,
     )
 
     if ((duplicateCounts.reference + duplicateCounts.actual) > 0 && !config.allowDuplicates) {
-      dfsDuplicates.reference.foreach(x => write(dfsWithKey.reference, x, "/refDuplicates"))
-      dfsDuplicates.actual.foreach(x => write(dfsWithKey.actual, x, "/newDuplicates"))
-
-      throw DuplicateRowsInDF(cliOptions.outOptions.path)
+      throw DuplicateRowsInDF(duplicateCounts.reference, duplicateCounts.actual)
     }
 
     duplicateCounts

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparison.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparison.scala
@@ -166,7 +166,7 @@ class DatasetComparison(cliOptions: CliOptions,
   }
 
   /**
-   * Handles duplicates in a sense that this method looks for them based on a primary key. Then based on the
+   * Counts duplicates within both provided dataframes based on the primary key. Then depending on the
    * configuration, if found, throws an error.
    *
    * @param dfsWithKey DataFrame pair where both have appended unique key

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/Exceptions.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/Exceptions.scala
@@ -56,8 +56,11 @@ final case class BadProvidedSchema(refPath: String,
        |$diffSchema""".stripMargin,
     cause)
 
-final case class DuplicateRowsInDF(path: String)
-  extends DatasetComparisonException(s"Provided dataset has duplicate rows. Specific rows written to $path")
+final case class DuplicateRowsInDF(countRef: Long, countNew: Long)
+  extends DatasetComparisonException(
+    s"""Provided datasets have duplicate rows.
+       |Reference Dataset has $countRef
+       |New Dataset has $countNew""".stripMargin)
 
 final case class MissingArgumentException(message: String, cause: Throwable = None.orNull)
   extends Exception(message, cause)

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/Exceptions.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/Exceptions.scala
@@ -59,8 +59,8 @@ final case class BadProvidedSchema(refPath: String,
 final case class DuplicateRowsInDF(countRef: Long, countNew: Long)
   extends DatasetComparisonException(
     s"""Provided datasets have duplicate rows.
-       |Reference Dataset has $countRef
-       |New Dataset has $countNew""".stripMargin)
+       |Reference Dataset has $countRef duplicates
+       |New Dataset has $countNew duplicates""".stripMargin)
 
 final case class MissingArgumentException(message: String, cause: Throwable = None.orNull)
   extends Exception(message, cause)

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonJobSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonJobSuite.scala
@@ -180,7 +180,7 @@ class DatasetComparisonJobSuite extends FunSuite with SparkTestBase with BeforeA
     val newPath = getClass.getResource("/dataSample5.csv").toString
     val outPath = s"target/test_output/comparison_job/negative/$timePrefix"
     val message = s"""Provided datasets have duplicate rows.
-                     |Reference Dataset has 0  duplicates
+                     |Reference Dataset has 0 duplicates
                      |New Dataset has 1 duplicates""".stripMargin
 
     val args = Array(

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonJobSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonJobSuite.scala
@@ -179,7 +179,9 @@ class DatasetComparisonJobSuite extends FunSuite with SparkTestBase with BeforeA
     val refPath = getClass.getResource("/dataSample1.csv").toString
     val newPath = getClass.getResource("/dataSample5.csv").toString
     val outPath = s"target/test_output/comparison_job/negative/$timePrefix"
-    val message = s"Provided dataset has duplicate rows. Specific rows written to $outPath"
+    val message = s"""Provided datasets have duplicate rows.
+                     |Reference Dataset has 0
+                     |New Dataset has 1""".stripMargin
 
     val args = Array(
       "--new-format", "csv",
@@ -197,7 +199,6 @@ class DatasetComparisonJobSuite extends FunSuite with SparkTestBase with BeforeA
     }
 
     assert(caught.getMessage == message)
-    assert(Files.exists(Paths.get(outPath)))
   }
 
   test("Compare nested structures with errors") {

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonJobSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonJobSuite.scala
@@ -180,8 +180,8 @@ class DatasetComparisonJobSuite extends FunSuite with SparkTestBase with BeforeA
     val newPath = getClass.getResource("/dataSample5.csv").toString
     val outPath = s"target/test_output/comparison_job/negative/$timePrefix"
     val message = s"""Provided datasets have duplicate rows.
-                     |Reference Dataset has 0
-                     |New Dataset has 1""".stripMargin
+                     |Reference Dataset has 0  duplicates
+                     |New Dataset has 1 duplicates""".stripMargin
 
     val args = Array(
       "--new-format", "csv",


### PR DESCRIPTION
### Description
Removed the duplicate writing feature. Realized that this made no sense to have / did not fit into the scope of things making DataSetComparison a swiss knife for no reason.

### Previous behaviour
On duplicate data, DatasetComparison wrote out rows of differences into a separate dataset

### Current behaviour
On duplicate data, DatasetComparison throws an error saying how many differences there are.

### Modules affected
- [x] DatasetComparison
- [ ] InfoFileComparison
- [ ] E2ERunner

### Other
- [ ] Has new configs 
- [ ] Requires Docs update
- [ ] Introduces new logs
- [ ] Introduces new error messages

Fixes #83 
