### PR TITLE
8 Add cross-compilation

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -22,24 +22,13 @@ on:
     branches: [ master, develop ]
 
 jobs:
-  test:
+  license-test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        scala: [2.11, 2.12]
-        spark: [2.4, 3.1]
-        exclude:
-          - scala: 2.11
-            spark: 3.1
-    name: Test Spark ${{matrix.spark}} on Scala ${{matrix.scala}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - uses: coursier/cache-action@v5
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:
           java-version: "adopt@1.8"
-      - name: Build and run tests
-        run: sbt ++${{matrix.scala}} test -DSPARK_VERSION=${{matrix.spark}}
+      - run: sbt headerCheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
         scala: [2.11.12, 2.12.12]
         spark: [2.4.7, 3.1.1]
         exclude:
-          - scala: 2.11
-            spark: 3.1
+          - scala: 2.11.12
+            spark: 3.1.1
     name: Test Spark ${{matrix.spark}} on Scala ${{matrix.scala}}
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.11, 2.12]
+        scala: [2.11.12, 2.12.12]
         spark: [2.4, 3.1]
         exclude:
           - scala: 2.11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         scala: [2.11.12, 2.12.12]
-        spark: [2.4, 3.1]
+        spark: [2.4.7, 3.1.1]
         exclude:
           - scala: 2.11
             spark: 3.1

--- a/README.md
+++ b/README.md
@@ -13,16 +13,18 @@ Hermes is an E2E testing tool created mainly for the use in [ABSA OSS][gh-absa] 
 
 ## To Build
 
+Use either of the commands below. Depending on your versions.
 ```bash
-sbt assembly
+sbt ++2.11.12 assembly -DSPARK_VERSION=2.4.7
+sbt ++2.12.12 assembly -DSPARK_VERSION=2.4.7
+sbt ++2.12.12 assembly -DSPARK_VERSION=3.1.1
 ```
 
 Known to work with:
 
-- Spark 2.4.4
-- Java 1.8.0_191-b12
-- Scala 2.11.12
-- Hadoop 2.7.5
+- Spark 2.4 and 3.1
+- Java 1.8
+- Scala 2.11.12 and 2.12.12
 
 ## Dataset Comparison
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,12 @@
 
 ThisBuild / organization := "za.co.absa.hermes"
 ThisBuild / name         := "hermes"
-ThisBuild / scalaVersion := "2.11.12"
+
+lazy val scala211 = "2.11.12"
+lazy val scala212 = "2.12.12"
+
+ThisBuild / scalaVersion := scala211
+ThisBuild / crossScalaVersions := Seq(scala211, scala212)
 
 Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
 

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparatorJobSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparatorJobSuite.scala
@@ -200,10 +200,7 @@ class DatasetComparatorJobSuite extends FunSuite with SparkTestBase with BeforeA
   }
 
   test("Compare nested structures with errors") {
-    val path: URL = getClass.getResource("/json_output.txt")
-    val lines: List[String] = FileReader.usingFile(Source.fromURL(path)) { _.getLines().toList }
-    val outCapture = new ByteArrayOutputStream
-
+    val expexted = Array("WrappedArray(legs_0_conditions_0_checks_0_checkNums_5)", "WrappedArray(legs_0_legid)")
     val refPath = getClass.getResource("/json_orig").toString
     val newPath = getClass.getResource("/json_changed").toString
     val outPath = s"target/test_output/comparison_job/negative/$timePrefix"
@@ -220,11 +217,9 @@ class DatasetComparatorJobSuite extends FunSuite with SparkTestBase with BeforeA
       DatasetComparisonJob.main(args)
     }
     val df = spark.read.format("parquet").load(outPath)
+    val actual: Array[String] = df.select("errCol").collect().flatMap(_.toSeq).map(_.toString)
 
-    Console.withOut(outCapture) { df.show(false) }
-    val result = new String(outCapture.toByteArray).replace("\r\n", "\n").split("\n").toList
-
-    assert(lines == result)
+    assert(actual sameElements expexted)
   }
 
   test("Key based compare of xml files with compound keys") {

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparatorJobSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparatorJobSuite.scala
@@ -200,7 +200,7 @@ class DatasetComparatorJobSuite extends FunSuite with SparkTestBase with BeforeA
   }
 
   test("Compare nested structures with errors") {
-    val expexted = Array("WrappedArray(legs_0_conditions_0_checks_0_checkNums_5)", "WrappedArray(legs_0_legid)")
+    val expected = Array("WrappedArray(legs_0_conditions_0_checks_0_checkNums_5)", "WrappedArray(legs_0_legid)")
     val refPath = getClass.getResource("/json_orig").toString
     val newPath = getClass.getResource("/json_changed").toString
     val outPath = s"target/test_output/comparison_job/negative/$timePrefix"

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparatorJobSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparatorJobSuite.scala
@@ -219,7 +219,7 @@ class DatasetComparatorJobSuite extends FunSuite with SparkTestBase with BeforeA
     val df = spark.read.format("parquet").load(outPath)
     val actual: Array[String] = df.select("errCol").collect().flatMap(_.toSeq).map(_.toString)
 
-    assert(actual sameElements expexted)
+    assert(actual sameElements expected)
   }
 
   test("Key based compare of xml files with compound keys") {


### PR DESCRIPTION
### Description
Add cross-compilation for scala and spark

### New behaviour
Now Hermes can be used for scala 2.12 and Spark 3.1.1 as well

### Modules affected
- [x] DatasetComparison
- [ ] InfoFileComparison
- [ ] E2ERunner

### Other
- [ ] Has new configs 
- [x] Requires Docs update
- [ ] Introduces new logs
- [ ] Introduces new error messages

Fixes #8 
