### PR TITLE
81 Logg efective configuration for DatasetComparison

### DIFF
--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonJob.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonJob.scala
@@ -86,7 +86,9 @@ object DatasetComparisonJob {
   }
 
   def getConfig(configPath: Option[String]): DatasetComparisonConfig = {
-    new TypesafeConfig(configPath).validate().get
+    val config = new TypesafeConfig(configPath).validate().get
+    scribe.info(config.getLoggableString)
+    config
   }
 
   def writeMetricsToFile(result: ComparisonResult, fileName: String)

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/config/DatasetComparisonConfig.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/config/DatasetComparisonConfig.scala
@@ -43,4 +43,13 @@ abstract class DatasetComparisonConfig {
       _expectedPrefix <- validateColumnName(expectedPrefix, "expectedPrefix")
     } yield this
   }
+
+  def getLoggableString: String = {
+    s"""Effective DatasetComparison configuration:
+       | Error Column Name (errorColumnName) -> "$errorColumnName"
+       | Prefix of original columns (expectedPrefix) -> "$expectedPrefix"
+       | Prefix of new columns (actualPrefix) -> "$actualPrefix"
+       | Allow duplicities in dataframes (allowDuplicates) -> "$allowDuplicates"
+       |""".stripMargin
+  }
 }

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/config/DatasetComparisonConfig.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/config/DatasetComparisonConfig.scala
@@ -49,7 +49,6 @@ abstract class DatasetComparisonConfig {
        | Error Column Name (errorColumnName) -> "$errorColumnName"
        | Prefix of original columns (expectedPrefix) -> "$expectedPrefix"
        | Prefix of new columns (actualPrefix) -> "$actualPrefix"
-       | Allow duplicities in dataframes (allowDuplicates) -> "$allowDuplicates"
-       |""".stripMargin
+       | Allow duplicities in dataframes (allowDuplicates) -> "$allowDuplicates"""".stripMargin
   }
 }

--- a/infoFileComparison/src/main/scala/za/co/absa/hermes/infoFileComparison/InfoFileComparisonConfig.scala
+++ b/infoFileComparison/src/main/scala/za/co/absa/hermes/infoFileComparison/InfoFileComparisonConfig.scala
@@ -21,7 +21,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 case class InfoFileComparisonConfig(versionMetaKeys: List[String], keysToIgnore: List[String]) {
   def getLoggableString: String = {
     s"""Effective InfoFileComparison configuration:
-       | Meta Keys indicating version that are only to be printed:
+       | Meta Keys (indicating versions) only to be printed:
        |  ${versionMetaKeys.mkString("\n  ")}
        | Meta Keys to be ignored:
        |  ${keysToIgnore.mkString("\n  ")}""".stripMargin

--- a/infoFileComparison/src/main/scala/za/co/absa/hermes/infoFileComparison/InfoFileComparisonConfig.scala
+++ b/infoFileComparison/src/main/scala/za/co/absa/hermes/infoFileComparison/InfoFileComparisonConfig.scala
@@ -18,7 +18,15 @@ package za.co.absa.hermes.infoFileComparison
 
 import com.typesafe.config.{Config, ConfigFactory}
 
-case class InfoFileComparisonConfig(versionMetaKeys: List[String], keysToIgnore: List[String])
+case class InfoFileComparisonConfig(versionMetaKeys: List[String], keysToIgnore: List[String]) {
+  def getLoggableString: String = {
+    s"""Effective InfoFileComparison configuration:
+       | Meta Keys indicating version that are only to be printed:
+       |  ${versionMetaKeys.mkString("\n  ")}
+       | Meta Keys to be ignored:
+       |  ${keysToIgnore.mkString("\n  ")}""".stripMargin
+  }
+}
 
 object InfoFileComparisonConfig {
   def fromTypesafeConfig(path: Option[String] = None): InfoFileComparisonConfig = {

--- a/infoFileComparison/src/main/scala/za/co/absa/hermes/infoFileComparison/InfoFileComparisonJob.scala
+++ b/infoFileComparison/src/main/scala/za/co/absa/hermes/infoFileComparison/InfoFileComparisonJob.scala
@@ -56,6 +56,7 @@ object InfoFileComparisonJob {
     val newControlMeasure = loadControlMeasures(cmd.newPath)
     val refControlMeasure = loadControlMeasures(cmd.refPath)
     val config = InfoFileComparisonConfig.fromTypesafeConfig(configPath)
+    scribe.info(config.getLoggableString)
 
     val diff: List[ModelDifference[_]] = compare(newControlMeasure, refControlMeasure, config)
 


### PR DESCRIPTION
### Description
Now the active configuration is printed.

### Previous behaviour
No logs

### Current behaviour
DatasetComparison and InfoFileComparison now prints an effective configuration used (specific to Hermes not spark and others)

### Modules affected
- [x] DatasetComparison
- [x] InfoFileComparison
- [ ] E2ERunner

### Other
- [ ] Has new configs 
- [ ] Requires Docs update
- [x] Introduces new logs
- [ ] Introduces new error messages

Fixes #81 
