### PR TITLE
90 Add Spark Version Guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Hermes is an E2E testing tool created mainly for the use in [ABSA OSS][gh-absa] 
 sbt assembly
 ```
 
-Known to work with:
+## Known to work with:
 
-- Spark 2.4.4
+- Spark 2.4.2 - 3.1.1
+  - There are now spark version guards to protect from false positives. If there is someone willing to test for older versions, we are happy to extend these.
 - Java 1.8.0_191-b12
 - Scala 2.11.12
 - Hadoop 2.7.5

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ sbt assembly
 
 ## Known to work with:
 
-- Spark 2.4.2 - 3.1.1
-  - There are now spark version guards to protect from false positives. If there is someone willing to test for older versions, we are happy to extend these.
+- Spark 2.4.2 - 3.1.1 [1]
 - Java 1.8.0_191-b12
-- Scala 2.11.12
-- Hadoop 2.7.5
+- Scala 2.11.12 and 2.12.12
+
+[1] There are now spark version guards to protect from false positives. 
+If there is someone willing to test for older versions, we are happy to extend these.
+These are applicable only to use as a spark-job not as a library
 
 ## Dataset Comparison
 

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonJob.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparisonJob.scala
@@ -17,17 +17,20 @@
 package za.co.absa.hermes.datasetComparison
 
 import java.io.PrintWriter
-
 import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.SPARK_VERSION
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.{DataType, StructType}
 import za.co.absa.hermes.datasetComparison.cliUtils.{CliParameters, CliParametersParser}
 import za.co.absa.hermes.datasetComparison.config.{DatasetComparisonConfig, TypesafeConfig}
 import za.co.absa.hermes.datasetComparison.dataFrame.Utils
+import za.co.absa.hermes.utils.SparkCompatibility
 
 object DatasetComparisonJob {
 
   def main(args: Array[String]): Unit = {
+    SparkCompatibility.checkVersion(SPARK_VERSION)
+
     val cliParameters = CliParametersParser.parse(args)
 
     implicit val sparkSession: SparkSession = SparkSession.builder()

--- a/e2eRunner/src/main/scala/za/co/absa/hermes/e2eRunner/E2ERunnerJob.scala
+++ b/e2eRunner/src/main/scala/za/co/absa/hermes/e2eRunner/E2ERunnerJob.scala
@@ -16,11 +16,13 @@
 
 package za.co.absa.hermes.e2eRunner
 
-import java.io.File
+import org.apache.spark.SPARK_VERSION
 
+import java.io.File
 import za.co.absa.hermes.e2eRunner.logging.LoggingFunctions
 import za.co.absa.hermes.e2eRunner.logging.functions.Scribe
 import za.co.absa.hermes.e2eRunner.plugins.FailedPluginResult
+import za.co.absa.hermes.utils.SparkCompatibility
 
 import scala.util.{Failure, Success, Try}
 
@@ -33,6 +35,8 @@ object E2ERunnerJob {
   ).getPath
 
   def main(args: Array[String]): Unit = {
+    SparkCompatibility.checkVersion(SPARK_VERSION)
+
     val cmd = E2ERunnerConfig.getCmdLineArguments(args) match {
       case Success(value) => value
       case Failure(exception) => throw exception

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,17 +31,19 @@ object Dependencies {
   private val atumModelVersion = "3.5.0"
   private val commonsVersion = "0.0.14"
   private val hofsVersion = "0.4.0"
+  private val absaCommonsVersion = "0.0.27"
 
   private val scalatestVersion = "3.0.5"
 
   def sparkVersion: String = sys.props.getOrElse("SPARK_VERSION", "2.4.7")
 
   val baseDependencies = List(
-    "com.github.scopt" %% "scopt"       % scoptVersion,
-    "com.outr"         %% "scribe"      % scribeVersion,
-    "com.typesafe"     %  "config"      % typeSafeConfigVersion,
-    "io.spray"         %%  "spray-json" % sprayJsonVersion,
-    "org.scalatest"    %% "scalatest"   % scalatestVersion       % Test
+    "com.github.scopt"   %% "scopt"       % scoptVersion,
+    "com.outr"           %% "scribe"      % scribeVersion,
+    "com.typesafe"       %  "config"      % typeSafeConfigVersion,
+    "io.spray"           %%  "spray-json" % sprayJsonVersion,
+    "org.scalatest"      %% "scalatest"   % scalatestVersion       % Test,
+    "za.co.absa.commons" %% "commons"     % absaCommonsVersion
   )
 
   val e2eDependencies = List(

--- a/utils/src/main/scala/za/co/absa/hermes/utils/SparkCompatibility.scala
+++ b/utils/src/main/scala/za/co/absa/hermes/utils/SparkCompatibility.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hermes.utils
+
+import za.co.absa.commons.version.Version._
+import za.co.absa.commons.version.impl.SemVer20Impl.SemanticVersion
+
+object SparkCompatibility {
+  val minSparkVersionIncluded: SemanticVersion = semver"2.4.2"
+  val maxSparkVersionExcluded: SemanticVersion = semver"3.2.0"
+
+  def checkVersion(sparkVersion: String): Unit = {
+    val version = asSemVer(sparkVersion)
+    require(version >= minSparkVersionIncluded && version < maxSparkVersionExcluded,
+      s"Spark's version must be more then $minSparkVersionIncluded (including) and less then (excluding) $maxSparkVersionExcluded")
+  }
+}

--- a/utils/src/main/scala/za/co/absa/hermes/utils/SparkCompatibility.scala
+++ b/utils/src/main/scala/za/co/absa/hermes/utils/SparkCompatibility.scala
@@ -26,6 +26,6 @@ object SparkCompatibility {
   def checkVersion(sparkVersion: String): Unit = {
     val version = asSemVer(sparkVersion)
     require(version >= minSparkVersionIncluded && version < maxSparkVersionExcluded,
-      s"Spark's version must be more then $minSparkVersionIncluded (including) and less then (excluding) $maxSparkVersionExcluded")
+      s"Spark version must be more than $minSparkVersionIncluded (including) and less than (excluding) $maxSparkVersionExcluded")
   }
 }


### PR DESCRIPTION
### Description
Add spark version guards for spark-job classes

### Previous behaviour
No version guards

### Current behaviour
If Project is run with a provided spark that is too old or too new version, it will stop on failed requirement.

### Modules affected
- [x] DatasetComparison
- [ ] InfoFileComparison
- [x] E2ERunner

### Other
- [ ] Has new configs 
- [x] Requires Docs update
- [ ] Introduces new logs
- [x] Introduces new error messages

Fixes #90 
