### PR TITLE
Release/0.3.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ lazy val scala212 = "2.12.12"
 
 ThisBuild / scalaVersion := scala211
 ThisBuild / crossScalaVersions := Seq(scala211, scala212)
+ThisBuild / releaseCrossBuild := true
 
 Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.2"
+version in ThisBuild := "0.4.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,17 +1,1 @@
-/*
- * Copyright 2019 ABSA Group Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-version in ThisBuild := "0.4.0-SNAPSHOT"
+version in ThisBuild := "0.3.2"


### PR DESCRIPTION
### Current behaviour
- added cross-compilation
  - scala 2.11 and 2.12
  - also tested with spark 2.4.7 and 3.1.1
- update Atum version to 3.5.0 from 0.2.6
- add spark version guards
- Log Effective Configuration used by the run