### PR TITLE
92 Fix Key column generation

### DIFF
--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparator.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparator.scala
@@ -265,11 +265,12 @@ class DatasetComparator(dataFrameReference: DataFrame,
    * @return Returns a DataFrame with key column appended
    */
   private def addKeyColumn(selector: List[Column], df: DataFrame, cmpUniqueColumn: String): DataFrame = {
-    if (keys.nonEmpty) {
-      df.withColumn(cmpUniqueColumn, md5(concat_ws("|", keys.map(col).toSeq: _*)))
+    val concatenatedColumns = if (keys.nonEmpty) {
+      for(i <- keys.map(col).toSeq; p <- Seq(lit("|"), i)) yield p
     } else {
-      df.withColumn(cmpUniqueColumn, md5(concat_ws("|", selector: _*)))
+      for(i <- selector; p <- Seq(lit("|"), i)) yield p
     }
+    df.withColumn(cmpUniqueColumn, md5(concat(concatenatedColumns: _*)))
   }
 
   /**

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparator.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparator.scala
@@ -265,12 +265,12 @@ class DatasetComparator(dataFrameReference: DataFrame,
    * @return Returns a DataFrame with key column appended
    */
   private def addKeyColumn(selector: List[Column], df: DataFrame, cmpUniqueColumn: String): DataFrame = {
-    val concatenatedColumns = if (keys.nonEmpty) {
-      for(i <- keys.map(col).toSeq; p <- Seq(lit("|"), i)) yield p
+    val columnsToConcatenate = if (keys.nonEmpty) {
+      keys.map(col(_).cast("string")).toSeq
     } else {
-      for(i <- selector; p <- Seq(lit("|"), i)) yield p
+      selector.map(_.cast("string"))
     }
-    df.withColumn(cmpUniqueColumn, md5(concat(concatenatedColumns: _*)))
+    df.withColumn(cmpUniqueColumn, md5(concat_ws("|", columnsToConcatenate: _*)))
   }
 
   /**

--- a/datasetComparison/src/test/resources/dataSample2.json
+++ b/datasetComparison/src/test/resources/dataSample2.json
@@ -1,0 +1,9 @@
+{"id": "1","first_name": "Pierette","last_name": "Sawyer", "struct": { "other_key": "value1" }}
+{"id": "2","first_name": "Jillian","last_name": "Gorriessen", "struct": { "other_key":  "value2" }}
+{"id": "3","first_name": "Ronnie","last_name": "Meredyth", "struct": { "other_key":  "value3" }}
+{"id": "4","first_name": "Elora","last_name": "Willox", "struct": { "other_key":  "value4" }}
+{"id": "5","first_name": "Thom","last_name": "Serraillier", "struct": { "other_key":  "value5" }}
+{"id": "6","first_name": "Megan","last_name": "Danhel", "struct": { "other_key":  "value6" }}
+{"id": "7","first_name": "Holly-anne","last_name": "Whatman", "struct": { "other_key":  "value7" }}
+{"id": "8","first_name": "Hedda","last_name": "Flips", "struct": { "other_key":  "value8" }}
+{"id": "9","first_name": "Heloise","last_name": "Tims", "struct": { "other_key":  "value9" }}

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparatorJobSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparatorJobSuite.scala
@@ -16,7 +16,6 @@
 
 package za.co.absa.hermes.datasetComparison
 
-import java.io.ByteArrayOutputStream
 import java.net.URL
 import java.nio.file.{Files, Paths}
 import java.text.SimpleDateFormat
@@ -44,6 +43,21 @@ class DatasetComparatorJobSuite extends FunSuite with SparkTestBase with BeforeA
       "--delimiter", ",",
       "--new-path", getClass.getResource("/dataSample1.csv").toString,
       "--ref-path", getClass.getResource("/dataSample2.csv").toString,
+      "--out-path", outPath
+    )
+
+    DatasetComparisonJob.main(args)
+
+    assert(Files.exists(Paths.get(outPath,"_METRICS")))
+  }
+
+  test("Compare the same datasets by generic way - complex structure") {
+    val outPath = s"target/test_output/comparison_job/positive/$timePrefix"
+
+    val args = Array(
+      "--format", "json",
+      "--new-path", getClass.getResource("/dataSample2.json").toString,
+      "--ref-path", getClass.getResource("/dataSample2.json").toString,
       "--out-path", outPath
     )
 


### PR DESCRIPTION
### Previous behaviour
If people did not provide keys for dataset comparison and data had complex columns, the key column generation would fail because it used `concat_ws`.

### Current behaviour
~~Now we use classic `concat` with inserted `lit("|")` in between.~~

Concat proved to have the same problems. Using a cast to string on all top-level fields now.

### Modules affected
- [x] DatasetComparison
- [ ] InfoFileComparison
- [ ] E2ERunner

### Other
- [ ] Has new configs 
- [ ] Requires Docs update
- [ ] Introduces new logs
- [ ] Introduces new error messages

Fixes #92
