### PR TITLE
#107 First take on this

### DIFF
--- a/datasetComparison/src/main/scala/org/apache/spark/sql/AccessShowString.scala
+++ b/datasetComparison/src/main/scala/org/apache/spark/sql/AccessShowString.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+object AccessShowString {
+  /**
+   * Exposure of showString method. Compose the string representing rows for show output. Truncate enforced.
+   *
+   * @param truncate If set to more than 0, truncates strings to `truncate` characters and
+   *                   all cells will be aligned right.
+   * @param vertical If set to true, prints output rows vertically (one line per column value).
+   * @param df DataFrame to get a show string representation
+   * @param _numRows Number of rows to show. Defaults to 20
+   * @return String representation of Dataframe
+   */
+  def showString(df: DataFrame,
+                 _numRows: Int = 20,
+                 vertical: Boolean = false): String = {
+    df.showString(_numRows, truncate = 0, vertical = vertical)
+  }
+}

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparator.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparator.scala
@@ -18,7 +18,7 @@ package za.co.absa.hermes.datasetComparison
 
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{StructField, StructType}
-import org.apache.spark.sql.{Column, DataFrame, SparkSession}
+import org.apache.spark.sql.{Column, DataFrame}
 import za.co.absa.commons.spark.SchemaUtils
 import za.co.absa.hermes.datasetComparison.config.{DatasetComparisonConfig, TypesafeConfig}
 import za.co.absa.hermes.utils.HelperFunctions
@@ -36,14 +36,12 @@ import za.co.absa.hermes.utils.HelperFunctions
  * @param optionalSchema Optional schema to cherry-pick columns form the two dataframes to compare. For example, if you
  *                       have a timestamp column that will never be the same, you provide a schema without that timestamp
  *                       and it will not be compared.
- * @param sparkSession Implicit spark session.
  */
 class DatasetComparator(dataFrameReference: DataFrame,
                         dataFrameActual: DataFrame,
                         keys: Set[String] = Set.empty[String],
                         config: DatasetComparisonConfig = new TypesafeConfig(None),
-                        optionalSchema: Option[StructType] = None)
-                       (implicit sparkSession: SparkSession) {
+                        optionalSchema: Option[StructType] = None) {
 
   /**
    * Case class created for the single purpose of holding a pair of reference and tested data in any form together.

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/UnitTestDataFrame.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/UnitTestDataFrame.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hermes.datasetComparison
+
+import org.apache.spark.sql.{AccessShowString, DataFrame}
+import za.co.absa.hermes.datasetComparison.config.ManualConfig
+
+case class DataFrameMismatch(msg: String) extends Exception(msg)
+
+object UnitTestDataFrame {
+
+  /**
+   * Assertion style metod for the usage of DatasetComparator in Unit Tests
+   *
+   * @param actualDF Actual DataFrame
+   * @param expectedDF Expected DataFrame
+   * @param allowDuplicates Should assertion fail if it encounters duplicities. Defaults to true.
+   * @param keys Keys for usage as precise row identification. Defaults to an empty Set
+   * @param numRows Number of rows to be printed in case of mismatch. Defaults to 20.
+   */
+  def assertDataFrame(actualDF: DataFrame,
+                      expectedDF: DataFrame,
+                      allowDuplicates: Boolean = true,
+                      keys: Set[String] = Set.empty[String],
+                      numRows: Int = 20): Unit = {
+    val config = new ManualConfig(
+      errorColumnName = "errCol",
+      actualPrefix = "actual",
+      expectedPrefix = "expected",
+      allowDuplicates = allowDuplicates
+    )
+    val result = new DatasetComparator(expectedDF, actualDF, keys, config).compare
+
+    if (!result.passed) {
+      val message = AccessShowString.showString(result.resultDF.get, numRows)
+      throw DataFrameMismatch(message)
+    }
+
+  }
+}

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/UnitTestDataFrameTest.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/UnitTestDataFrameTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hermes.datasetComparison
+
+import org.scalatest.{Assertions, FunSuite}
+import za.co.absa.hermes.datasetComparison.cliUtils.CliParameters
+import za.co.absa.hermes.datasetComparison.dataFrame.{Parameters, Utils}
+import za.co.absa.hermes.utils.SparkTestBase
+import za.co.absa.hermes.datasetComparison.UnitTestDataFrame._
+
+class UnitTestDataFrameTest extends FunSuite with SparkTestBase {
+  test("Test assertion") {
+    val cliOptions = new CliParameters(
+      Parameters("csv", Map("delimiter" -> ","), getClass.getResource("/dataSample5.csv").toString),
+      Parameters("csv", Map("delimiter" -> ","), getClass.getResource("/dataSample6.csv").toString),
+      Some(Parameters("parquet", Map.empty[String, String], "path/to/nowhere")),
+      Set.empty[String],
+      "--bogus raw-options"
+    )
+
+    val df1 = Utils.loadDataFrame(cliOptions.referenceDataParameters)
+    val df2 = Utils.loadDataFrame(cliOptions.actualDataParameters)
+
+    assertDataFrame(df1, df2, keys = Set("_c0"))
+  }
+}


### PR DESCRIPTION
### Description
Add UnitTesting object and an assert function

**NOTE**: Failed tests in GH Actions is to see what it does.

### Previous behaviour
_No previous behaviour_

### Current behaviour
There is an object `UnitTestDataFrame` and function `assertDataFrame` to be used for unit testing. I exposed the `showString` for this purpose.

### Modules affected
- [x] DatasetComparison
- [ ] InfoFileComparison
- [ ] E2ERunner

### Other
- [ ] Has new configs 
- [x] Requires Docs update
- [ ] Introduces new logs
- [x] Introduces new error messages

Fixes #107 
