### PR TITLE
115 Fix S3 path resolving

### DIFF
--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/PathResolver.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/PathResolver.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hermes.datasetComparison
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import za.co.absa.hermes.datasetComparison.dataFrame.S3Location.StringS3LocationExt
+
+import java.net.URI
+
+case class PathResolver(fs: FileSystem, fullPath: String, basePath: String) {
+  def fsExists: Boolean = fs.exists(new Path(basePath))
+
+  def updatePathSuffix(newBasePath: String): PathResolver = {
+    val newFullPath = fullPath.replaceAllLiterally(basePath, newBasePath)
+    PathResolver(fs, newFullPath, newBasePath)
+  }
+
+  def getPathWithTimestamp: PathResolver = {
+    updatePathSuffix(s"${basePath}_${System.currentTimeMillis .toString}")
+  }
+}
+
+object PathResolver {
+  /**
+   * Converts string full path to Hadoop FS and Path, e.g.
+   * `s3://mybucket1/path/to/file` -> S3 FS + `path/to/file`
+   * `/path/on/hdfs/to/file` -> local HDFS + `/path/on/hdfs/to/file`
+   *
+   * Note, that non-local HDFS paths are not supported in this method, e.g. hdfs://nameservice123:8020/path/on/hdfs/too.
+   *
+   * @param pathString path to convert to FS and relative path
+   * @return FS + relative path
+   **/
+  def pathStringToFsWithPath(pathString: String, conf: Configuration): PathResolver = {
+    pathString.toS3Location match {
+      case Some(s3Location) =>
+        val s3Uri = new URI(s3Location.s3String) // s3://<bucket>
+        val s3Path = s"/${s3Location.path}" // /<text-file-object-path>
+
+        val fs = FileSystem.get(s3Uri, conf)
+        PathResolver(fs, s3Uri.toString, s3Path)
+
+      case None => // local hdfs location
+        val fs = FileSystem.get(conf)
+        PathResolver(fs, pathString, pathString)
+    }
+  }
+}

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/cliUtils/CliParametersParser.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/cliUtils/CliParametersParser.scala
@@ -29,7 +29,7 @@ private case class OptionsTrio(reference: Map[String, String],
     OptionsTrio(
       genericMap ++ reference,
       genericMap ++ actual,
-      genericMap ++ output
+      (genericMap - "format") ++ output
     )
   }
 

--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/dataFrame/S3Location.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/dataFrame/S3Location.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hermes.datasetComparison.dataFrame
+
+import scala.util.matching.Regex
+
+object S3Location {
+
+  /**
+   * Generally usable regex for validating S3 path, e.g. `s3://my-cool-bucket1/path/to/file/on/s3.txt`
+   * Protocols `s3`, `s3n`, and `s3a` are allowed.
+   * Bucket naming rules defined at [[https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules]] are instilled.
+   */
+  private val S3LocationRx: Regex = "(s3[an]?)://([-a-z0-9.]{3,63})/(.*)".r
+
+  implicit class StringS3LocationExt(val path: String) extends AnyVal {
+
+    def toS3Location: Option[SimpleS3Location] = PartialFunction.condOpt(path) {
+      case S3LocationRx(protocol, bucketName, relativePath) =>
+        SimpleS3Location(protocol, bucketName, relativePath)
+    }
+
+    def isValidS3Path: Boolean = S3LocationRx.pattern.matcher(path).matches
+  }
+}
+
+case class SimpleS3Location(protocol: String, bucketName: String, path: String) {
+  def s3String: String = s"$protocol://$bucketName/$path"
+}

--- a/e2eRunner/src/main/scala/za/co/absa/hermes/e2eRunner/plugins/DatasetComparisonPlugin.scala
+++ b/e2eRunner/src/main/scala/za/co/absa/hermes/e2eRunner/plugins/DatasetComparisonPlugin.scala
@@ -19,7 +19,7 @@ package za.co.absa.hermes.e2eRunner.plugins
 import org.apache.spark.sql.SparkSession
 import za.co.absa.hermes.datasetComparison.cliUtils.CliParametersParser
 import za.co.absa.hermes.datasetComparison.dataFrame.{Parameters, Utils}
-import za.co.absa.hermes.datasetComparison.{ComparisonResult, DatasetComparator, DatasetComparisonJob}
+import za.co.absa.hermes.datasetComparison.{ComparisonResult, DatasetComparator, DatasetComparisonJob, PathResolver}
 import za.co.absa.hermes.e2eRunner.logging.{ErrorResultLog, InfoResultLog, ResultLog}
 import za.co.absa.hermes.e2eRunner.{Plugin, PluginResult, SparkBase, TestDefinition}
 import za.co.absa.hermes.utils.HelperFunctions
@@ -47,7 +47,9 @@ case class DatasetComparisonResult(arguments: Array[String],
       )
     }
 
-    DatasetComparisonJob.writeMetricsToFile(returnedValue, outDFOptions.path)
+
+    val pr = PathResolver.pathStringToFsWithPath(outDFOptions.path, spark.sparkContext.hadoopConfiguration)
+    DatasetComparisonJob.writeMetricsToFile(returnedValue, pr)
   }
 
   /**


### PR DESCRIPTION
S3 path resolving was broken when implementing a reentrantness for the comparison

### Previous behaviour
S3 paths for EMRFS were not resolved properly and Metrics could not be written

### Current behaviour
S3 paths for EMRFS resolve properly and Metrics are written

### Modules affected
- [x] DatasetComparison
- [ ] InfoFileComparison
- [x] E2ERunner

### Other
- [ ] Has new configs 
- [ ] Requires Docs update
- [ ] Introduces new logs
- [ ] Introduces new error messages

Fixes #115
