### PR TITLE
#120 Fix schema alignment check

### DIFF
--- a/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparator.scala
+++ b/datasetComparison/src/main/scala/za/co/absa/hermes/datasetComparison/DatasetComparator.scala
@@ -165,7 +165,7 @@ class DatasetComparator(dataFrameReference: DataFrame,
   def checkSchemas(testedDF: ComparisonPair[DataFrame], schema: StructType): Unit = {
     val expectedSchema: StructType = getSchemaWithoutMetadata(testedDF.reference.schema)
     val actualSchema: StructType = getSchemaWithoutMetadata(testedDF.actual.schema)
-    if (!schema.isSubset(actualSchema) && !schema.isSubset(expectedSchema)) {
+    if (!schema.isSubset(actualSchema) || !schema.isSubset(expectedSchema)) {
       val diffSchema = schema.diffSchema(actualSchema) ++
         schema.diffSchema(expectedSchema)
       throw BadProvidedSchema(diffSchema.mkString("\n"))

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparatorSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparatorSuite.scala
@@ -23,7 +23,6 @@ import za.co.absa.hermes.datasetComparison.cliUtils.CliParameters
 import za.co.absa.hermes.datasetComparison.config.ManualConfig
 import za.co.absa.hermes.datasetComparison.dataFrame.{Parameters, Utils}
 import za.co.absa.hermes.utils.SparkTestBase
-import za.co.absa.spark.commons.implicits.StructTypeImplicits.StructTypeEnhancements
 
 class DatasetComparatorSuite extends FunSuite with SparkTestBase with BeforeAndAfterAll {
   test("Test a positive comparison") {

--- a/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparatorSuite.scala
+++ b/datasetComparison/src/test/scala/za/co/absa/hermes/datasetComparison/DatasetComparatorSuite.scala
@@ -23,6 +23,7 @@ import za.co.absa.hermes.datasetComparison.cliUtils.CliParameters
 import za.co.absa.hermes.datasetComparison.config.ManualConfig
 import za.co.absa.hermes.datasetComparison.dataFrame.{Parameters, Utils}
 import za.co.absa.hermes.utils.SparkTestBase
+import za.co.absa.spark.commons.implicits.StructTypeImplicits.StructTypeEnhancements
 
 class DatasetComparatorSuite extends FunSuite with SparkTestBase with BeforeAndAfterAll {
   test("Test a positive comparison") {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,19 +31,21 @@ object Dependencies {
   private val atumModelVersion = "3.5.0"
   private val commonsVersion = "0.0.14"
   private val hofsVersion = "0.4.0"
-  private val absaCommonsVersion = "0.0.27"
+  private val absaCommonsVersion = "1.0.1"
+  private val absaSparkCommonsVersion = "0.2.0"
 
   private val scalatestVersion = "3.0.5"
 
   def sparkVersion: String = sys.props.getOrElse("SPARK_VERSION", "2.4.7")
 
   val baseDependencies = List(
-    "com.github.scopt"   %% "scopt"       % scoptVersion,
-    "com.outr"           %% "scribe"      % scribeVersion,
-    "com.typesafe"       %  "config"      % typeSafeConfigVersion,
-    "io.spray"           %%  "spray-json" % sprayJsonVersion,
-    "org.scalatest"      %% "scalatest"   % scalatestVersion       % Test,
-    "za.co.absa.commons" %% "commons"     % absaCommonsVersion
+    "com.github.scopt"   %% "scopt"         % scoptVersion,
+    "com.outr"           %% "scribe"        % scribeVersion,
+    "com.typesafe"       %  "config"        % typeSafeConfigVersion,
+    "io.spray"           %%  "spray-json"   % sprayJsonVersion,
+    "org.scalatest"      %% "scalatest"     % scalatestVersion       % Test,
+    "za.co.absa.commons" %% "commons"       % absaCommonsVersion,
+    "za.co.absa"         %% "spark-commons" % absaSparkCommonsVersion
   )
 
   val e2eDependencies = List(


### PR DESCRIPTION
### Description
- add new spark-commons and update commons
- fix the schema alignment check, bad brackets

### Previous behaviour
When using passing schema do dataset comparison, it would say schema is bad even though it wasn't

### Current behaviour
Passing the schema to dataset comparison works again

### Modules affected
- [x] DatasetComparison
- [ ] InfoFileComparison
- [ ] E2ERunner

### Other
- [ ] Has new configs 
- [ ] Requires Docs update
- [ ] Introduces new logs
- [ ] Introduces new error messages

Fixes #120 
