### PR TITLE
#129 - Update BashPlugin to support windows

### DIFF
--- a/e2eRunner/src/main/scala/za/co/absa/hermes/e2eRunner/plugins/BashPlugin.scala
+++ b/e2eRunner/src/main/scala/za/co/absa/hermes/e2eRunner/plugins/BashPlugin.scala
@@ -53,13 +53,17 @@ class BashPlugin extends Plugin {
 
   override def performAction(testDefinition: TestDefinition, actualOrder: Int): BashJobsResult = {
     def runBashCmd(bashCmd: String): String = {
-      (s"echo $bashCmd" #| "bash").!!
+      if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+        (s"cmd /C ${bashCmd.replace("'", "\"")}").!!
+      } else {
+        (s"echo $bashCmd" #| "bash").!!
+      }
     }
 
     val args = testDefinition.args
     val testName = testDefinition.name
 
-    scribe.info(s"Running bash with: ${args.mkString(" ")}")
+    scribe.info(s"Running command with: ${args.mkString(" ")}")
     val (confTime, returnValue) = HelperFunctions.calculateTime { runBashCmd(args.mkString(" ")) }
     val additionalInfo = Map("elapsedTimeInMilliseconds" -> confTime.toString)
     BashJobsResult(args, returnValue, actualOrder, testName, passed = true, additionalInfo)

--- a/e2eRunner/src/main/scala/za/co/absa/hermes/e2eRunner/plugins/BashPlugin.scala
+++ b/e2eRunner/src/main/scala/za/co/absa/hermes/e2eRunner/plugins/BashPlugin.scala
@@ -52,11 +52,11 @@ class BashPlugin extends Plugin {
   override def name: String = "BashPlugin"
 
   override def performAction(testDefinition: TestDefinition, actualOrder: Int): BashJobsResult = {
-    def runBashCmd(bashCmd: String): String = {
+    def runCmd(cmd: String): String = {
       if (System.getProperty("os.name").toLowerCase().contains("windows")) {
-        (s"cmd /C ${bashCmd.replace("'", "\"")}").!!
+        (s"cmd /C ${cmd.replace("'", "\"")}").!!
       } else {
-        (s"echo $bashCmd" #| "bash").!!
+        (s"echo $cmd" #| "bash").!!
       }
     }
 
@@ -64,7 +64,7 @@ class BashPlugin extends Plugin {
     val testName = testDefinition.name
 
     scribe.info(s"Running command with: ${args.mkString(" ")}")
-    val (confTime, returnValue) = HelperFunctions.calculateTime { runBashCmd(args.mkString(" ")) }
+    val (confTime, returnValue) = HelperFunctions.calculateTime { runCmd(args.mkString(" ")) }
     val additionalInfo = Map("elapsedTimeInMilliseconds" -> confTime.toString)
     BashJobsResult(args, returnValue, actualOrder, testName, passed = true, additionalInfo)
   }


### PR DESCRIPTION
- Added additional support to call command line command on windows OS

### Description
BashPlugin can newly operate on windows too without test json file change.

### Previous behaviour
Call command line commands - limited on unix only.

### Current behaviour
Call command line command on unix and windows.

### Modules affected
- [ ] DatasetComparison
- [ ] InfoFileComparison
- [x] E2ERunner

Closes #129 
