### PR TITLE
#134 - Add code coverage support improve

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,16 +24,30 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        scala: [2.11.12, 2.12.12]
+#        spark: [2.4.7, 3.2.2]
+#        exclude:
+#          - scala: 2.11.12
+#            spark: 3.2.2
+#          - scala: 2.12.12
+#            spark: 2.4.7
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.11.12, 2.12.12]
-        spark: [2.4.7, 3.2.2]
-        exclude:
+        include:
           - scala: 2.11.12
-            spark: 3.2.2
-          - scala: 2.12.12
+            scalaShort: "2.11"
             spark: 2.4.7
+            overall: 87.0
+            changed: 80.0
+          - scala: 2.12.12
+            scalaShort: "2.12"
+            spark: 3.2.2
+            overall: 87.0
+            changed: 80.0
     name: Test Spark ${{matrix.spark}} on Scala ${{matrix.scala}}
     steps:
       - name: Checkout code
@@ -44,4 +58,28 @@ jobs:
         with:
           java-version: "adopt@1.8"
       - name: Build and run tests
-        run: sbt ++${{matrix.scala}} test -DSPARK_VERSION=${{matrix.spark}}
+        run: sbt ++${{matrix.scala}} jacoco -DSPARK_VERSION=${{matrix.spark}}
+      - name: Add coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.3
+        with:
+          paths: >
+            ${{ github.workspace }}/datasetComparison/target/scala-${{ matrix.scalaShort }}/jacoco/report/jacoco.xml,
+            ${{ github.workspace }}/e2eRunner/target/scala-${{ matrix.scalaShort }}/jacoco/report/jacoco.xml,
+            ${{ github.workspace }}/infoFileComparison/target/scala-${{ matrix.scalaShort }}/jacoco/report/jacoco.xml,
+            ${{ github.workspace }}/utils/target/scala-${{ matrix.scalaShort }}/jacoco/report/jacoco.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: ${{ matrix.overall }}
+          min-coverage-changed-files: ${{ matrix.changed }}
+          title: JaCoCo code coverage report - scala ${{ matrix.scala }}
+          update-comment: true
+      - name: Get the Coverage info
+        run: |
+          echo "Total coverage ${{ steps.jacoco.outputs.coverage-overall }}"
+          echo "Changed Files coverage ${{ steps.jacoco.outputs.coverage-changed-files }}"
+      - name: Fail PR if changed files coverage is less than ${{ matrix.changed }}%
+        if: ${{ steps.jacoco.outputs.coverage-changed-files < 80.0 }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.setFailed('Changed files coverage is less than ${{ matrix.changed }}%!')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,16 +24,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        scala: [2.11.12, 2.12.12]
-#        spark: [2.4.7, 3.2.2]
-#        exclude:
-#          - scala: 2.11.12
-#            spark: 3.2.2
-#          - scala: 2.12.12
-#            spark: 2.4.7
     strategy:
       fail-fast: false
       matrix:
@@ -41,12 +31,12 @@ jobs:
           - scala: 2.11.12
             scalaShort: "2.11"
             spark: 2.4.7
-            overall: 87.0
+            overall: 0.0
             changed: 80.0
           - scala: 2.12.12
             scalaShort: "2.12"
             spark: 3.2.2
-            overall: 87.0
+            overall: 0.0
             changed: 80.0
     name: Test Spark ${{matrix.spark}} on Scala ${{matrix.scala}}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ ThisBuild / name         := "hermes"
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.12"
 
-ThisBuild / scalaVersion := scala211
+ThisBuild / scalaVersion := scala212
 ThisBuild / crossScalaVersions := Seq(scala211, scala212)
 ThisBuild / releaseCrossBuild := true
 
@@ -87,7 +87,7 @@ lazy val datasetComparison = project
     addArtifact(artifact in (Compile, assembly), assembly)
   )
   .settings(
-    jacocoReportSettings := commonJacocoReportSettings.withTitle(s"hermes:dataset-comparison_scala_${scalaVersion.value} Jacoco Report"),
+    jacocoReportSettings := commonJacocoReportSettings.withTitle(s"hermes:dataset-comparison Jacoco Report - scala:${scalaVersion.value}"),
     jacocoExcludes := commonJacocoExcludes
   )
   .enablePlugins(AutomateHeaderPlugin)
@@ -108,7 +108,7 @@ lazy val e2eRunner = project
     addArtifact(artifact in (Compile, assembly), assembly)
   )
   .settings(
-    jacocoReportSettings := commonJacocoReportSettings.withTitle(s"hermes:e2e-runner_scala_${scalaVersion.value} Jacoco Report"),
+    jacocoReportSettings := commonJacocoReportSettings.withTitle(s"hermes:e2e-runner Jacoco Report - scala:${scalaVersion.value}"),
     jacocoExcludes := commonJacocoExcludes
   )
   .enablePlugins(AutomateHeaderPlugin)
@@ -129,7 +129,7 @@ lazy val infoFileComparison = project
     addArtifact(artifact in (Compile, assembly), assembly)
   )
   .settings(
-    jacocoReportSettings := commonJacocoReportSettings.withTitle(s"hermes:info-file-comparison_scala_${scalaVersion.value} Jacoco Report"),
+    jacocoReportSettings := commonJacocoReportSettings.withTitle(s"hermes:info-file-comparison Jacoco Report - scala:${scalaVersion.value}"),
     jacocoExcludes := commonJacocoExcludes
   )
   .enablePlugins(AutomateHeaderPlugin)
@@ -147,7 +147,7 @@ lazy val utils = project
     addArtifact(artifact in (Compile, assembly), assembly)
   )
   .settings(
-    jacocoReportSettings := commonJacocoReportSettings.withTitle(s"hermes:utils_scala_${scalaVersion.value} Jacoco Report"),
+    jacocoReportSettings := commonJacocoReportSettings.withTitle(s"hermes:utils Jacoco Report - scala:${scalaVersion.value}"),
     jacocoExcludes := commonJacocoExcludes
   )
   .enablePlugins(AutomateHeaderPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,4 +18,22 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
-addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.4.0")
+
+// sbt-jacoco - workaround related dependencies required to download
+lazy val ow2Version = "9.5"
+lazy val jacocoVersion = "0.8.9-absa.1"
+
+def jacocoUrl(artifactName: String): String = s"https://github.com/AbsaOSS/jacoco/releases/download/$jacocoVersion/org.jacoco.$artifactName-$jacocoVersion.jar"
+def ow2Url(artifactName: String): String = s"https://repo1.maven.org/maven2/org/ow2/asm/$artifactName/$ow2Version/$artifactName-$ow2Version.jar"
+
+addSbtPlugin("com.jsuereth" %% "scala-arm" % "2.0" from "https://repo1.maven.org/maven2/com/jsuereth/scala-arm_2.11/2.0/scala-arm_2.11-2.0.jar")
+addSbtPlugin("com.jsuereth" %% "scala-arm" % "2.0" from "https://repo1.maven.org/maven2/com/jsuereth/scala-arm_2.12/2.0/scala-arm_2.12-2.0.jar")
+
+addSbtPlugin("za.co.absa.jacoco" % "report" % jacocoVersion from jacocoUrl("report"))
+addSbtPlugin("za.co.absa.jacoco" % "core" % jacocoVersion from jacocoUrl("core"))
+addSbtPlugin("za.co.absa.jacoco" % "agent" % jacocoVersion from jacocoUrl("agent"))
+addSbtPlugin("org.ow2.asm" % "asm" % ow2Version from ow2Url("asm"))
+addSbtPlugin("org.ow2.asm" % "asm-commons" % ow2Version from ow2Url("asm-commons"))
+addSbtPlugin("org.ow2.asm" % "asm-tree" % ow2Version from ow2Url("asm-tree"))
+
+addSbtPlugin("za.co.absa.sbt" % "sbt-jacoco" % "3.4.1-absa.2" from "https://github.com/AbsaOSS/sbt-jacoco/releases/download/3.4.1-absa.2/sbt-jacoco-3.4.1-absa.2.jar")


### PR DESCRIPTION
- Used Absa fork of JaCoCo solution - with scala method filtering.
- Added support for code coverage GitHub action check as part of PR.
- Change default version of scala to 2.12 to stop failing IJ sbt libraries loading. Reason is that default version od spark od 3.2.2.

Closes #134 